### PR TITLE
Added tf2_geometry_msgs to Fix Humble Build

### DIFF
--- a/oxts_ins/CMakeLists.txt
+++ b/oxts_ins/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_kdl REQUIRED)
 find_package(oxts_msgs REQUIRED)
 
@@ -39,6 +40,7 @@ ament_target_dependencies(oxts_ins
                           geometry_msgs
                           nav_msgs
                           tf2
+                          tf2_geometry_msgs
                           tf2_kdl
                           oxts_msgs)
 target_include_directories(oxts_ins PUBLIC

--- a/oxts_ins/include/oxts_ins/wrapper.hpp
+++ b/oxts_ins/include/oxts_ins/wrapper.hpp
@@ -44,8 +44,8 @@
 #include <oxts_msgs/msg/nav_sat_ref.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
-#include "tf2_kdl/tf2_kdl.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_kdl/tf2_kdl.hpp"
 
 // OxTS includes
 #include "oxts_ins/NComRxC.h"

--- a/oxts_ins/package.xml
+++ b/oxts_ins/package.xml
@@ -16,6 +16,7 @@
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_kdl</depend>
   <depend>oxts_msgs</depend>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_kdl REQUIRED)
 find_package(oxts_msgs REQUIRED)
@@ -49,6 +50,7 @@ ament_target_dependencies(tests
         geometry_msgs
         nav_msgs
         tf2
+        tf2_geometry_msgs
         tf2_kdl
         oxts_msgs)
 


### PR DESCRIPTION
On ROS Humble there were some Errors when building the Node for example:
`/opt/ros_ws/src/oxts_ros2_driver/oxts_ins/include/oxts_ins/wrapper.hpp:47:10: fatal error: tf2_geometry_msgs/tf2_geometry_msgs.h: No such file or directory
   47 | #include "tf2_geometry_msgs/tf2_geometry_msgs.h"`

These additions fixes the issue.