### PR TITLE
Several small fixes

### DIFF
--- a/oxts_ins/CMakeLists.txt
+++ b/oxts_ins/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_kdl REQUIRED)
 find_package(oxts_msgs REQUIRED)
 
@@ -39,6 +40,7 @@ ament_target_dependencies(oxts_ins
                           geometry_msgs
                           nav_msgs
                           tf2
+                          tf2_geometry_msgs
                           tf2_kdl
                           oxts_msgs)
 target_include_directories(oxts_ins PUBLIC

--- a/oxts_ins/include/oxts_ins/convert.hpp
+++ b/oxts_ins/include/oxts_ins/convert.hpp
@@ -155,6 +155,8 @@ private:
   void imu(std_msgs::msg::Header header);
   /** Callback function for Tf messages. Wraps messages and broadcasts. */
   void tf(const std_msgs::msg::Header &header);
+
+  void tf_world_to_base_link(const std_msgs::msg::Header &header);
   /** Callback function for TimeReference message. Wraps message and publishes.
    */
   void time_reference(std_msgs::msg::Header header);

--- a/oxts_ins/include/oxts_ins/wrapper.hpp
+++ b/oxts_ins/include/oxts_ins/wrapper.hpp
@@ -44,8 +44,8 @@
 #include <oxts_msgs/msg/nav_sat_ref.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
-#include "tf2_kdl/tf2_kdl.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_kdl/tf2_kdl.hpp"
 
 // OxTS includes
 #include "oxts_ins/NComRxC.h"

--- a/oxts_ins/include/oxts_ins/wrapper.hpp
+++ b/oxts_ins/include/oxts_ins/wrapper.hpp
@@ -184,7 +184,7 @@ geometry_msgs::msg::TwistStamped velocity(const NComRxC *nrx,
  * @returns
  */
 nav_msgs::msg::Odometry odometry(const NComRxC *nrx,
-                                 const std_msgs::msg::Header &head, Lrf lrf);
+                                 const std_msgs::msg::Header &head, Lrf lrf, const std::string &frame_id);
 /**
  * Wrap navigation data from NCom decoder to nav_msgs/msg/Path
  *

--- a/oxts_ins/package.xml
+++ b/oxts_ins/package.xml
@@ -16,6 +16,7 @@
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_kdl</depend>
   <depend>oxts_msgs</depend>
 

--- a/oxts_ins/src/conversions/convert.cpp
+++ b/oxts_ins/src/conversions/convert.cpp
@@ -62,7 +62,7 @@ void OxtsIns::string() {
 }
 
 void OxtsIns::nav_sat_fix(std_msgs::msg::Header header) {
-  header.frame_id = "navsat_link";
+  header.frame_id = this->frame_id;
   auto msg = RosNComWrapper::nav_sat_fix(this->nrx, header);
   pubNavSatFix_->publish(msg);
 }
@@ -71,26 +71,26 @@ void OxtsIns::nav_sat_ref(std_msgs::msg::Header header) {
   // Set the LRF if - we haven't set it before (unless using NCOM LRF)
   this->getLrf();
   if (this->lrf_valid) {
-    header.frame_id = "navsat_link";
+    header.frame_id = this->frame_id;
     auto msg = RosNComWrapper::nav_sat_ref(this->lrf, header);
     pubNavSatRef_->publish(msg);
   }
 }
 
 void OxtsIns::lever_arm_gap(std_msgs::msg::Header header) {
-  header.frame_id = "oxts_link";
+  header.frame_id = this->frame_id;
   auto msg = RosNComWrapper::lever_arm_gap(this->nrx, header);
   pubLeverArm_->publish(msg);
 }
 
 void OxtsIns::imu_bias(std_msgs::msg::Header header) {
-  header.frame_id = "oxts_link";
+  header.frame_id = this->frame_id;
   auto msg = RosNComWrapper::imu_bias(this->nrx, header);
   pubIMUBias_->publish(msg);
 }
 
 void OxtsIns::ecef_pos(std_msgs::msg::Header header) {
-  header.frame_id = "oxts_link";
+  header.frame_id = this->frame_id;
   auto msg = RosNComWrapper::ecef_pos(this->nrx, header);
   pubEcefPos_->publish(msg);
 }
@@ -105,11 +105,11 @@ void OxtsIns::tf(const std_msgs::msg::Header &header) {
   // Set the LRF if - we haven't set it before (unless using NCOM LRF)
   this->getLrf();
   if (this->lrf_valid) {
-    auto odometry = RosNComWrapper::odometry(this->nrx, header, this->lrf);
+    auto odometry = RosNComWrapper::odometry(this->nrx, header, this->lrf, this->frame_id);
     geometry_msgs::msg::TransformStamped tf_oxts;
     tf_oxts.header = header;
     tf_oxts.header.frame_id = this->pub_odometry_frame_id;
-    tf_oxts.child_frame_id = "oxts_link";
+    tf_oxts.child_frame_id = this->frame_id;
     tf_oxts.transform.translation.x = odometry.pose.pose.position.x;
     tf_oxts.transform.translation.y = odometry.pose.pose.position.y;
     tf_oxts.transform.translation.z = odometry.pose.pose.position.z;
@@ -122,7 +122,7 @@ void OxtsIns::tf(const std_msgs::msg::Header &header) {
     if (this->nrx->mIsNoSlipLeverArmXValid) {
       geometry_msgs::msg::TransformStamped tf_vat;
       tf_vat.header = header;
-      tf_vat.header.frame_id = "oxts_link";
+      tf_vat.header.frame_id = this->frame_id;
       tf_vat.child_frame_id = "rear_axle_link";
       tf_vat.transform.translation.x = nsp.x();
       tf_vat.transform.translation.y = nsp.y();
@@ -143,7 +143,7 @@ void OxtsIns::tf(const std_msgs::msg::Header &header) {
 
         geometry_msgs::msg::TransformStamped tf_front_axle;
         tf_front_axle.header = header;
-        tf_front_axle.header.frame_id = "oxts_link";
+        tf_front_axle.header.frame_id = this->frame_id;
         tf_front_axle.child_frame_id = "front_axle_link";
         tf_front_axle.transform.translation.x = nvsp.x();
         tf_front_axle.transform.translation.y = nvsp.y();
@@ -159,7 +159,7 @@ void OxtsIns::tf(const std_msgs::msg::Header &header) {
 }
 
 void OxtsIns::velocity(std_msgs::msg::Header header) {
-  header.frame_id = "oxts_link";
+  header.frame_id = this->frame_id;
   auto msg = RosNComWrapper::velocity(this->nrx, header);
   pubVelocity_->publish(msg);
 }
@@ -169,7 +169,7 @@ void OxtsIns::odometry(std_msgs::msg::Header header) {
   // Set the LRF if - we haven't set it before (unless using NCOM LRF)
   this->getLrf();
   if (this->lrf_valid) {
-    auto msg = RosNComWrapper::odometry(this->nrx, header, this->lrf);
+    auto msg = RosNComWrapper::odometry(this->nrx, header, this->lrf, this->frame_id);
     if (this->pubPathInterval) {
       auto new_pose_stamped = geometry_msgs::msg::PoseStamped();
       new_pose_stamped.header = msg.header;
@@ -187,7 +187,7 @@ void OxtsIns::path(std_msgs::msg::Header header) {
 }
 
 void OxtsIns::time_reference(std_msgs::msg::Header header) {
-  header.frame_id = "oxts_link";
+  header.frame_id = this->frame_id;
   auto msg = RosNComWrapper::time_reference(this->nrx, header);
   pubTimeReference_->publish(msg);
 }

--- a/oxts_ins/src/conversions/convert.cpp
+++ b/oxts_ins/src/conversions/convert.cpp
@@ -146,8 +146,8 @@ void OxtsIns::tf_world_to_base_link(const std_msgs::msg::Header &header) {
         tf_world_to_base_link.getOrigin().getX();
     tf_world_to_base_link_msg.transform.translation.y =
         tf_world_to_base_link.getOrigin().getY();
-    tf_world_to_base_link_msg.transform.translation.z =
-        tf_world_to_base_link.getOrigin().getZ();
+    tf_world_to_base_link_msg.transform.translation.z = 0.0;
+    // tf_world_to_base_link.getOrigin().getZ() < 0 ? 0 : tf_world_to_base_link.getOrigin().getZ();
     tf_world_to_base_link_msg.transform.rotation.x =
         tf_world_to_base_link.getRotation().getX();
     tf_world_to_base_link_msg.transform.rotation.y =

--- a/oxts_ins/src/conversions/convert.cpp
+++ b/oxts_ins/src/conversions/convert.cpp
@@ -143,6 +143,10 @@ void OxtsIns::tf_world_to_base_link(const std_msgs::msg::Header &header) {
     tf_world_to_base_link_msg.header.frame_id = this->pub_odometry_frame_id;
     tf_world_to_base_link_msg.child_frame_id = this->base_link_frame_id;
     tf_world_to_base_link_msg.transform.translation.x =
+        tf_world_to_base_link.getOrigin().getX();
+    tf_world_to_base_link_msg.transform.translation.y =
+        tf_world_to_base_link.getOrigin().getY();
+    tf_world_to_base_link_msg.transform.translation.z =
         tf_world_to_base_link.getOrigin().getZ();
     tf_world_to_base_link_msg.transform.rotation.x =
         tf_world_to_base_link.getRotation().getX();

--- a/oxts_ins/src/conversions/convert.cpp
+++ b/oxts_ins/src/conversions/convert.cpp
@@ -129,10 +129,8 @@ void OxtsIns::tf(const std_msgs::msg::Header &header) {
     geometry_msgs::msg::TransformStamped tf_world_to_base_link_msg;
     tf_world_to_base_link_msg.header = header;
     tf_world_to_base_link_msg.header.frame_id = this->pub_odometry_frame_id;
-    tf_world_to_base_link_msg.child_frame_id = this->frame_id;
-    tf_world_to_base_link_msg.transform.translation.x = tf_world_to_base_link.getOrigin().getX();
-    tf_world_to_base_link_msg.transform.translation.y = tf_world_to_base_link.getOrigin().getY();
-    tf_world_to_base_link_msg.transform.translation.z = tf_world_to_base_link.getOrigin().getZ();
+    tf_world_to_base_link_msg.child_frame_id = this->base_link_frame_id;
+    tf_world_to_base_link_msg.transform.translation.x = tf_world_to_base_link.getOrigin().getZ();
     tf_world_to_base_link_msg.transform.rotation.x = tf_world_to_base_link.getRotation().getX();
     tf_world_to_base_link_msg.transform.rotation.y = tf_world_to_base_link.getRotation().getY();
     tf_world_to_base_link_msg.transform.rotation.z = tf_world_to_base_link.getRotation().getZ();

--- a/oxts_ins/src/conversions/convert.cpp
+++ b/oxts_ins/src/conversions/convert.cpp
@@ -106,15 +106,41 @@ void OxtsIns::tf(const std_msgs::msg::Header &header) {
   this->getLrf();
   if (this->lrf_valid) {
     auto odometry = RosNComWrapper::odometry(this->nrx, header, this->lrf, this->frame_id);
-    geometry_msgs::msg::TransformStamped tf_oxts;
-    tf_oxts.header = header;
-    tf_oxts.header.frame_id = this->pub_odometry_frame_id;
-    tf_oxts.child_frame_id = this->frame_id;
-    tf_oxts.transform.translation.x = odometry.pose.pose.position.x;
-    tf_oxts.transform.translation.y = odometry.pose.pose.position.y;
-    tf_oxts.transform.translation.z = odometry.pose.pose.position.z;
-    tf_oxts.transform.rotation = odometry.pose.pose.orientation;
-    tf_broadcaster_->sendTransform(tf_oxts);
+    tf2::Transform tf_world_to_oxts;
+    tf_world_to_oxts.setOrigin(tf2::Vector3(odometry.pose.pose.position.x,
+                                            odometry.pose.pose.position.y,
+                                            odometry.pose.pose.position.z));
+    tf_world_to_oxts.setRotation(tf2::Quaternion(odometry.pose.pose.orientation.x, odometry.pose.pose.orientation.y,
+                                                 odometry.pose.pose.orientation.z, odometry.pose.pose.orientation.w));
+
+    auto tf_oxts_to_base_link_msg = this->tf_buffer->lookupTransform(this->frame_id, this->base_link_frame_id, tf2::TimePointZero);
+
+    tf2::Transform transfrom_oxts_to_base_link;
+    transfrom_oxts_to_base_link.setOrigin(tf2::Vector3(tf_oxts_to_base_link_msg.transform.translation.x,
+                                                       tf_oxts_to_base_link_msg.transform.translation.y,
+                                                       tf_oxts_to_base_link_msg.transform.translation.z));
+    transfrom_oxts_to_base_link.setRotation(tf2::Quaternion(tf_oxts_to_base_link_msg.transform.rotation.x,
+                                                           tf_oxts_to_base_link_msg.transform.rotation.y,
+                                                           tf_oxts_to_base_link_msg.transform.rotation.z,
+                                                           tf_oxts_to_base_link_msg.transform.rotation.w));
+
+    auto tf_world_to_base_link = tf_world_to_oxts * transfrom_oxts_to_base_link;
+
+    geometry_msgs::msg::TransformStamped tf_world_to_base_link_msg;
+    tf_world_to_base_link_msg.header = header;
+    tf_world_to_base_link_msg.header.frame_id = this->pub_odometry_frame_id;
+    tf_world_to_base_link_msg.child_frame_id = this->frame_id;
+    tf_world_to_base_link_msg.transform.translation.x = tf_world_to_base_link.getOrigin().getX();
+    tf_world_to_base_link_msg.transform.translation.y = tf_world_to_base_link.getOrigin().getY();
+    tf_world_to_base_link_msg.transform.translation.z = tf_world_to_base_link.getOrigin().getZ();
+    tf_world_to_base_link_msg.transform.rotation.x = tf_world_to_base_link.getRotation().getX();
+    tf_world_to_base_link_msg.transform.rotation.y = tf_world_to_base_link.getRotation().getY();
+    tf_world_to_base_link_msg.transform.rotation.z = tf_world_to_base_link.getRotation().getZ();
+    tf_world_to_base_link_msg.transform.rotation.w = tf_world_to_base_link.getRotation().getW();
+
+    tf_broadcaster_->sendTransform(tf_world_to_base_link_msg);
+
+
 
     auto vat = RosNComWrapper::getVat(this->nrx);
     auto nsp = RosNComWrapper::getNsp(this->nrx);

--- a/oxts_ins/src/conversions/wrapper.cpp
+++ b/oxts_ins/src/conversions/wrapper.cpp
@@ -320,10 +320,11 @@ tf2::Matrix3x3 getRotEnuToLrf(double theta) {
 }
 
 nav_msgs::msg::Odometry odometry(const NComRxC *nrx,
-                                 const std_msgs::msg::Header &head, Lrf lrf) {
+                                 const std_msgs::msg::Header &head, Lrf lrf, 
+                                 const std::string &frame_id) {
   auto msg = nav_msgs::msg::Odometry();
   msg.header = head;
-  msg.child_frame_id = "oxts_link";
+  msg.child_frame_id = frame_id;
   // pose with covariance ======================================================
 
   Point::Cart p_enu;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_kdl REQUIRED)
 find_package(oxts_msgs REQUIRED)
@@ -49,6 +50,7 @@ ament_target_dependencies(tests
         geometry_msgs
         nav_msgs
         tf2
+        tf2_geometry_msgs
         tf2_kdl
         oxts_msgs)
 

--- a/tests/wrapper.cpp
+++ b/tests/wrapper.cpp
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(odometry) {
   nrx.mWy = 70;
   nrx.mWz = 105;
 
-  auto msg = ::odometry(&nrx, std_msgs::msg::Header{}, Lrf{25, 45, 65, 123});
+  auto msg = ::odometry(&nrx, std_msgs::msg::Header{}, Lrf{25, 45, 65, 123}, "oxts_link");
 
   geometry_msgs::msg::Point expectedPosition{};
   expectedPosition.x = -979434.4658;


### PR DESCRIPTION
1. Frame ID from ros parameter - not hard-coded value.
2. @JonasHablitzelAVLD's tf2 fix
3. Add option to change which tf is being published (source and destination). This is now similar to what amcl would publish. 
4. z-coordinate is always set to zero and altitude is ignored (for now). This can be reverted for the main repo, or a parameter can be added so that it is optionally published. 